### PR TITLE
fix: 코멘트박스 하단 고정 후 채팅화면 잘리는 문제 보정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_size = 4

--- a/src/component/common/CommentBox.js
+++ b/src/component/common/CommentBox.js
@@ -61,7 +61,7 @@ export default function CommentBox({ post_id, setCommentList, commentList }) {
 
 const S_StickyBox = styled.div`
   position: sticky;
-  bottom: 0;
+  bottom: 0px;
 `
 const S_CommentBox = styled.div`
 	display: flex;
@@ -86,13 +86,14 @@ const S_CommentInput = styled.input`
 	border-radius: 18px;
 	border: 1px solid ${palette.bottomBar[2]};
 	background-color: ${palette.bottomBar[1]};
-	padding: 0 13px 1px;
+	padding: 0 38px 0 13px;
 	font-size: 14px;
+  line-height: 15px;
 	font-weight: 400;
 	::placeholder {
-		padding-bottom: 3px;
-		font-size: 12px;
-		font-weight: 300;
+    line-height: 20px;
+		font-size: 13px;
+		font-weight: 100;
 	}
 `;
 const S_CommentUploadButton = styled.img`

--- a/src/pages/Chat/ChatRoomPage.js
+++ b/src/pages/Chat/ChatRoomPage.js
@@ -14,7 +14,7 @@ export default function ChatRoomPage() {
 	return (
 		<>
 			<Header rightChild={<S_ModalBtn src={moreHeader} />} />
-			<S_main>
+			<S_Main>
 				<S_OtherPersonWrapper>
 					<S_OtherPersonImg src={userImg} />
 					<S_OtherPersonContent>{otherData}</S_OtherPersonContent>
@@ -23,7 +23,7 @@ export default function ChatRoomPage() {
 					<S_MyTextContent>아 거기 좋죠!!! 사진 여깄습니다!</S_MyTextContent>
 					<S_MyImg src={placeImg} />
 				</S_MyWrapper>
-			</S_main>
+			</S_Main>
 			<CommentBox boxIcon={boxIcon} />
 		</>
 	);
@@ -34,13 +34,16 @@ const S_ModalBtn = styled.img`
 	height: 22px;
 	cursor: pointer;
 `;
-const S_main = styled.main`
+const S_Main = styled.main`
 	justify-content: flex-end;
 	align-items: flex-start;
-	background-color: #fefcf3;
+	background-color: #FEFCF3;
 	padding: 20px;
 	font-size: 14px;
 	line-height: 19px;
+  position: relative;
+  height: calc(100vh - 48px);
+  overflow-y: scroll;
 `;
 const S_OtherPersonWrapper = styled.div`
 	display: flex;
@@ -62,6 +65,7 @@ const S_OtherPersonContent = styled.p`
 `;
 const S_MyWrapper = styled.div`
 	text-align: right;
+  padding-bottom: 40px;
 `;
 const S_MyTextContent = styled.p`
 	display: inline-block;


### PR DESCRIPTION
## 🌴 PR 목적
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [x] 버그 수정 : 
- [ ] 기타 : 

## 🌴 기대결과
- 코멘트박스 하단 고정 후 채팅 화면 잘리는 문제 보정됨

## 🌴 전달사항
- 추가로 깃헙에서 코드 볼 때 tap: 2칸 적용되도록 파일 추가합니다

## 🍀 Issue Number
close : #250
