### PR TITLE
fix: 댓글 새로 달리는 위치 수정

### DIFF
--- a/src/component/common/CommentBox.js
+++ b/src/component/common/CommentBox.js
@@ -15,7 +15,7 @@ export default function CommentBox({ post_id, setCommentList, commentList }) {
 
 	const btnClickEvent = () => {
 		postComment(post_id, commentContent).then((res) => {
-			setCommentList([...commentList, res.data.comment]);
+			setCommentList([res.data.comment, ...commentList]);
 		});
 		setCommentContent('');
 	};
@@ -37,32 +37,32 @@ export default function CommentBox({ post_id, setCommentList, commentList }) {
 	return (
 		<>
 			<S_StickyBox>
-			  <S_CommentBox>
-  				<S_UserIcon src={userImg} />
-  				<S_CommentInput
-  					ref={inputRef}
-  					onChange={CommentInputValidator}
-  					value={commentContent}
-  					placeholder="댓글 입력하기..."
-  					onKeyDown={enterEventHandler}
-  				/>
-  				{!!commentContent ? (
-  					<>
-  						<S_CommentUploadButton onClick={btnClickEvent} src={commentbtn} />
-  					</>
-  				) : (
-  					<></>
-  				)}
-  			</S_CommentBox>
+				<S_CommentBox>
+					<S_UserIcon src={userImg} />
+					<S_CommentInput
+						ref={inputRef}
+						onChange={CommentInputValidator}
+						value={commentContent}
+						placeholder="댓글 입력하기..."
+						onKeyDown={enterEventHandler}
+					/>
+					{!!commentContent ? (
+						<>
+							<S_CommentUploadButton onClick={btnClickEvent} src={commentbtn} />
+						</>
+					) : (
+						<></>
+					)}
+				</S_CommentBox>
 			</S_StickyBox>
 		</>
 	);
 }
 
 const S_StickyBox = styled.div`
-  position: sticky;
-  bottom: 0px;
-`
+	position: sticky;
+	bottom: 0px;
+`;
 const S_CommentBox = styled.div`
 	display: flex;
 	height: 60px;
@@ -88,10 +88,10 @@ const S_CommentInput = styled.input`
 	background-color: ${palette.bottomBar[1]};
 	padding: 0 38px 0 13px;
 	font-size: 14px;
-  line-height: 15px;
+	line-height: 15px;
 	font-weight: 400;
 	::placeholder {
-    line-height: 20px;
+		line-height: 20px;
 		font-size: 13px;
 		font-weight: 100;
 	}

--- a/src/component/post/CommentItem.js
+++ b/src/component/post/CommentItem.js
@@ -95,7 +95,7 @@ const S_Comment = styled.div`
 	font-size: 14px;
 	font-weight: 400;
 `;
-const S_UserDate = styled.p`
+const S_UserDate = styled.div`
 	span {
 		color: #767676;
 		font-size: 12px;

--- a/src/component/post/PostDetailComment.js
+++ b/src/component/post/PostDetailComment.js
@@ -9,7 +9,7 @@ export default function PostDetailComment({ post_id, setCommentList, commentList
 			setCommentList([...res.data.comments]);
 		});
 	}, []);
-
+	console.log(commentList);
 	return (
 		<>
 			<S_CommentList>


### PR DESCRIPTION
댓글 새로 달면 상위에 포스트되고 새로고침시에도 동일하게 작동하도록 수정

## 🌴 PR 목적
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 : 
- [ ] 문서 수정 : 
- [x] 버그 수정 : fix: 댓글 새로 달리는 위치 수정
- [ ] 기타 : 

## 🌴 기대결과
- 댓글 새로 달아도 원래 댓글 시간 순서대로 달립니다. 

## 🌴 전달사항
- 

## 🍀 Issue Number
close : #
